### PR TITLE
Translate site to English and improve SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,23 +1,28 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Tying.ai - 智能AI助手，为您提供专业的AI解决方案。即将推出，敬请期待。">
-    <meta name="keywords" content="AI, 人工智能, 智能助手, Tying.ai, 即将推出">
+    <meta name="description" content="Tying.ai - Intelligent AI assistant providing professional AI solutions. Coming soon. Stay tuned.">
+    <meta name="keywords" content="AI, artificial intelligence, smart assistant, professional AI solutions, Tying.ai, coming soon">
     <meta name="author" content="Tying.ai">
     <meta name="robots" content="index, follow">
-    <meta property="og:title" content="Tying.ai - 智能AI助手">
-    <meta property="og:description" content="Tying.ai - 智能AI助手，为您提供专业的AI解决方案。即将推出，敬请期待。">
+    <meta name="googlebot" content="index, follow">
+    <meta property="og:title" content="Tying.ai - Intelligent AI Assistant">
+    <meta property="og:description" content="Tying.ai - Intelligent AI assistant providing professional AI solutions. Coming soon. Stay tuned.">
+    <meta property="og:locale" content="en_US">
+    <meta property="og:site_name" content="Tying.ai">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://tying.ai">
     <meta property="og:image" content="https://tying.ai/og-image.jpg">
+    <meta property="og:image:alt" content="Tying.ai Logo">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Tying.ai - 智能AI助手">
-    <meta name="twitter:description" content="Tying.ai - 智能AI助手，为您提供专业的AI解决方案。即将推出，敬请期待。">
+    <meta name="twitter:title" content="Tying.ai - Intelligent AI Assistant">
+    <meta name="twitter:description" content="Tying.ai - Intelligent AI assistant providing professional AI solutions. Coming soon. Stay tuned.">
     <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <link rel="canonical" href="https://tying.ai">
-    <title>Tying.ai - 智能AI助手 | 即将推出</title>
+    <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
+    <title>Tying.ai - Intelligent AI Assistant | Coming Soon</title>
     <style>
         * {
             margin: 0;
@@ -280,11 +285,11 @@
         <div class="noise"></div>
         <div class="material"></div>
         <h1>Tying.ai</h1>
-        <p class="tagline">智能 AI 助手</p>
-        <p class="description">为您提供专业的 AI 解决方案</p>
+        <p class="tagline">Intelligent AI Assistant</p>
+        <p class="description">Providing Professional AI Solutions</p>
         <div class="coming-soon">
             <span class="line"></span>
-            <span>即将推出</span>
+            <span>Coming Soon</span>
             <span class="line"></span>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- translate Chinese metadata and text on the landing page to English
- add Open Graph, Twitter, and Googlebot meta tags
- link to sitemap for improved crawling

## Testing
- `npm run build`
