### PR TITLE
Improve homepage SEO and content

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -3,16 +3,40 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Tying.ai - Smart AI Assistant. Coming soon.">
+    <meta name="description" content="Tying.ai offers smart AI assistant solutions for business automation. Coming soon.">
+    <meta name="keywords" content="AI assistant, generative AI, automation, Tying.ai">
+    <meta name="author" content="Tying.ai">
+    <meta name="robots" content="index, follow">
+    <meta property="og:title" content="Tying.ai - Smart AI Assistant">
+    <meta property="og:description" content="Tying.ai offers smart AI assistant solutions for business automation. Coming soon.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://tying.ai/">
+    <meta property="og:image" content="https://tying.ai/og-image.jpg">
+    <meta property="og:site_name" content="Tying.ai">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Tying.ai - Smart AI Assistant">
+    <meta name="twitter:description" content="Tying.ai offers smart AI assistant solutions for business automation. Coming soon.">
+    <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
+    <link rel="canonical" href="https://tying.ai/">
     <title>Tying.ai - Smart AI Assistant | Coming Soon</title>
     <link rel="stylesheet" href="minimal.css">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Tying.ai",
+      "url": "https://tying.ai",
+      "logo": "https://tying.ai/og-image.jpg"
+    }
+    </script>
 </head>
 <body>
-    <div class="container">
+    <main class="container">
         <h1>Tying.ai</h1>
         <p class="tagline">Smart AI Assistant</p>
-        <p class="description">Providing professional AI solutions</p>
+        <p class="description">We build AI tools that streamline workflows and improve productivity.</p>
+        <p class="about">Sign up to be the first to try our beta release.</p>
         <div class="coming-soon">Coming Soon</div>
-    </div>
+    </main>
 </body>
 </html>

--- a/index-optimized.html
+++ b/index-optimized.html
@@ -3,16 +3,34 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Tying.ai - Smart AI Assistant. Coming soon.">
-    <link rel="stylesheet" href="minimal.css">
+    <meta name="description" content="Tying.ai offers smart AI assistant solutions for business automation. Coming soon.">
+    <meta name="keywords" content="AI assistant, generative AI, automation, Tying.ai">
+    <meta name="author" content="Tying.ai">
+    <meta name="robots" content="index, follow">
+    <meta property="og:title" content="Tying.ai - Smart AI Assistant">
+    <meta property="og:description" content="Tying.ai offers smart AI assistant solutions for business automation. Coming soon.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://tying.ai/">
+    <meta property="og:image" content="https://tying.ai/og-image.jpg">
+    <meta property="og:site_name" content="Tying.ai">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Tying.ai - Smart AI Assistant">
+    <meta name="twitter:description" content="Tying.ai offers smart AI assistant solutions for business automation. Coming soon.">
+    <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
+    <link rel="canonical" href="https://tying.ai/">
     <title>Tying.ai - Smart AI Assistant | Coming Soon</title>
+    <link rel="stylesheet" href="minimal.css">
+    <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Organization","name":"Tying.ai","url":"https://tying.ai","logo":"https://tying.ai/og-image.jpg"}
+    </script>
 </head>
 <body>
-    <div class="container">
+    <main class="container">
         <h1>Tying.ai</h1>
         <p class="tagline">Smart AI Assistant</p>
-        <p class="description">Providing professional AI solutions</p>
+        <p class="description">We build AI tools that streamline workflows and improve productivity.</p>
+        <p class="about">Sign up to be the first to try our beta release.</p>
         <div class="coming-soon">Coming Soon</div>
-    </div>
+    </main>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,16 +3,40 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Tying.ai - Smart AI Assistant. Coming soon.">
+    <meta name="description" content="Tying.ai offers smart AI assistant solutions for business automation. Coming soon.">
+    <meta name="keywords" content="AI assistant, generative AI, automation, Tying.ai">
+    <meta name="author" content="Tying.ai">
+    <meta name="robots" content="index, follow">
+    <meta property="og:title" content="Tying.ai - Smart AI Assistant">
+    <meta property="og:description" content="Tying.ai offers smart AI assistant solutions for business automation. Coming soon.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://tying.ai/">
+    <meta property="og:image" content="https://tying.ai/og-image.jpg">
+    <meta property="og:site_name" content="Tying.ai">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Tying.ai - Smart AI Assistant">
+    <meta name="twitter:description" content="Tying.ai offers smart AI assistant solutions for business automation. Coming soon.">
+    <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
+    <link rel="canonical" href="https://tying.ai/">
     <title>Tying.ai - Smart AI Assistant | Coming Soon</title>
     <link rel="stylesheet" href="minimal.css">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Tying.ai",
+      "url": "https://tying.ai",
+      "logo": "https://tying.ai/og-image.jpg"
+    }
+    </script>
 </head>
 <body>
-    <div class="container">
+    <main class="container">
         <h1>Tying.ai</h1>
         <p class="tagline">Smart AI Assistant</p>
-        <p class="description">Providing professional AI solutions</p>
+        <p class="description">We build AI tools that streamline workflows and improve productivity.</p>
+        <p class="about">Sign up to be the first to try our beta release.</p>
         <div class="coming-soon">Coming Soon</div>
-    </div>
+    </main>
 </body>
 </html>

--- a/minimal.css
+++ b/minimal.css
@@ -27,6 +27,12 @@ h1 {
   margin-bottom: 2rem;
 }
 
+.about {
+  color: #555;
+  margin-bottom: 2rem;
+  font-size: 1rem;
+}
+
 .coming-soon {
   font-weight: bold;
   color: #333;


### PR DESCRIPTION
## Summary
- expand SEO meta tags on the landing page
- add short marketing blurb and signup prompt
- style new `.about` paragraph
- rebuild distribution files

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ea9cb5668832087203d209cd6bc08