### PR TITLE
Improve SEO metadata for wiki pages

### DIFF
--- a/scripts/update_seo.sh
+++ b/scripts/update_seo.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+for f in wiki/*.html; do
+  # ensure canonical has .html
+  if ! grep -qE 'rel="canonical" href="https://tying.ai/wiki/[^"?]*\.html"' "$f"; then
+    sed -i '/rel="canonical"/s|">|.html">|' "$f"
+  fi
+  # ensure og:url has .html
+  if ! grep -qE 'property="og:url" content="https://tying.ai/wiki/[^"?]*\.html"' "$f"; then
+    sed -i '/property="og:url"/s|">|.html">|' "$f"
+  fi
+  # add author meta if missing
+  if ! grep -q 'meta name="author"' "$f"; then
+    sed -i '/meta name="robots"/a\  <meta name="author" content="Tying.ai">' "$f"
+  fi
+  # add default og:image if missing
+  if ! grep -q 'og:image' "$f"; then
+    sed -i '/og:url/a\  <meta property="og:image" content="https://tying.ai/og-image.jpg">' "$f"
+  fi
+  # add twitter tags if missing
+  if ! grep -q 'twitter:card' "$f"; then
+    title=$(grep -m1 'property="og:title"' "$f" | sed 's/.*content="\([^"]*\)".*/\1/')
+    desc=$(grep -m1 'property="og:description"' "$f" | sed 's/.*content="\([^"]*\)".*/\1/')
+    sed -i "/og:image/a\  <meta name=\"twitter:card\" content=\"summary_large_image\">\n  <meta name=\"twitter:title\" content=\"$title\">\n  <meta name=\"twitter:description\" content=\"$desc\">\n  <meta name=\"twitter:image\" content=\"https://tying.ai/og-image.jpg\">" "$f"
+  fi
+done

--- a/wiki/1-1-aerospace-engineering-and-operations-technologists-and-technicians.html
+++ b/wiki/1-1-aerospace-engineering-and-operations-technologists-and-technicians.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Aerospace Engineering, Operations Technologist, Technician, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers">
   <link rel="canonical" href="https://tying.ai/wiki/1-1-aerospace-engineering-and-operations-technologists-and-technicians.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Aerospace Engineering and Operations Technologists and Technicians: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Aerospace Engineering and Operations Technologists and Technicians career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-1-aerospace-engineering-and-operations-technologists-and-technicians.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Aerospace Engineering and Operations Technologists and Technicians: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Aerospace Engineering and Operations Technologists and Technicians career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-10-computer-hardware-engineers.html
+++ b/wiki/1-10-computer-hardware-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Computer Hardware Engineer, Hardware Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Electronics">
   <link rel="canonical" href="https://tying.ai/wiki/1-10-computer-hardware-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Computer Hardware Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Computer Hardware Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-10-computer-hardware-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Computer Hardware Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Computer Hardware Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-11-drafters.html
+++ b/wiki/1-11-drafters.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Drafter, Drafting, Career, Salary, Job Outlook, Skills, How to Become, CAD, Technical Drawing, Engineering Support">
   <link rel="canonical" href="https://tying.ai/wiki/1-11-drafters.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Drafters: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Drafter career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-11-drafters.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Drafters: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Drafter career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-12-electrical-and-electronic-engineering-technologists-and-technicians.html
+++ b/wiki/1-12-electrical-and-electronic-engineering-technologists-and-technicians.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Electrical Engineering Technologist, Electronic Engineering Technician, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Electronics">
   <link rel="canonical" href="https://tying.ai/wiki/1-12-electrical-and-electronic-engineering-technologists-and-technicians.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Electrical and Electronic Engineering Technologists and Technicians: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Electrical and Electronic Engineering Technologist and Technician career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-12-electrical-and-electronic-engineering-technologists-and-technicians.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Electrical and Electronic Engineering Technologists and Technicians: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Electrical and Electronic Engineering Technologist and Technician career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-13-electrical-and-electronics-engineers.html
+++ b/wiki/1-13-electrical-and-electronics-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Electrical Engineer, Electronics Engineer, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Power Systems">
   <link rel="canonical" href="https://tying.ai/wiki/1-13-electrical-and-electronics-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Electrical and Electronics Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Electrical and Electronics Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-13-electrical-and-electronics-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Electrical and Electronics Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Electrical and Electronics Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-14-electro-mechanical-and-mechatronics-technologists-and-technicians.html
+++ b/wiki/1-14-electro-mechanical-and-mechatronics-technologists-and-technicians.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Electro-mechanical Technologist, Mechatronics Technician, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Automation">
   <link rel="canonical" href="https://tying.ai/wiki/1-14-electro-mechanical-and-mechatronics-technologists-and-technicians.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Electro-mechanical and Mechatronics Technologists and Technicians: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Electro-mechanical and Mechatronics Technologist and Technician career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-14-electro-mechanical-and-mechatronics-technologists-and-technicians.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Electro-mechanical and Mechatronics Technologists and Technicians: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Electro-mechanical and Mechatronics Technologist and Technician career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-15-environmental-engineering-technologists-and-technicians.html
+++ b/wiki/1-15-environmental-engineering-technologists-and-technicians.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Environmental Engineering Technologist, Environmental Technician, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Environmental Protection">
   <link rel="canonical" href="https://tying.ai/wiki/1-15-environmental-engineering-technologists-and-technicians.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Environmental Engineering Technologists and Technicians: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Environmental Engineering Technologist and Technician career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-15-environmental-engineering-technologists-and-technicians.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Environmental Engineering Technologists and Technicians: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Environmental Engineering Technologist and Technician career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-16-environmental-engineers.html
+++ b/wiki/1-16-environmental-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Environmental Engineer, Environmental Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Sustainability">
   <link rel="canonical" href="https://tying.ai/wiki/1-16-environmental-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Environmental Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Environmental Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-16-environmental-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Environmental Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Environmental Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-17-health-and-safety-engineers.html
+++ b/wiki/1-17-health-and-safety-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Health and Safety Engineer, Safety Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Occupational Safety">
   <link rel="canonical" href="https://tying.ai/wiki/1-17-health-and-safety-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Health and Safety Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Health and Safety Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-17-health-and-safety-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Health and Safety Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Health and Safety Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-18-industrial-engineering-technologists-and-technicians.html
+++ b/wiki/1-18-industrial-engineering-technologists-and-technicians.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Industrial Engineering Technologist, Industrial Engineering Technician, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Process Improvement">
   <link rel="canonical" href="https://tying.ai/wiki/1-18-industrial-engineering-technologists-and-technicians.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Industrial Engineering Technologists and Technicians: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Industrial Engineering Technologist and Technician career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-18-industrial-engineering-technologists-and-technicians.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Industrial Engineering Technologists and Technicians: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Industrial Engineering Technologist and Technician career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-19-industrial-engineers.html
+++ b/wiki/1-19-industrial-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Industrial Engineer, Industrial Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Process Optimization">
   <link rel="canonical" href="https://tying.ai/wiki/1-19-industrial-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Industrial Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Industrial Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-19-industrial-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Industrial Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Industrial Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-2-aerospace-engineers.html
+++ b/wiki/1-2-aerospace-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Aerospace Engineer, Aerospace Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers">
   <link rel="canonical" href="https://tying.ai/wiki/1-2-aerospace-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Aerospace Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Aerospace Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-2-aerospace-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Aerospace Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Aerospace Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-20-landscape-architects.html
+++ b/wiki/1-20-landscape-architects.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Landscape Architect, Landscape Architecture, Career, Salary, Job Outlook, Skills, How to Become, Design, Urban Planning, Environmental Design">
   <link rel="canonical" href="https://tying.ai/wiki/1-20-landscape-architects.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Landscape Architects: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Landscape Architect career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-20-landscape-architects.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Landscape Architects: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Landscape Architect career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-21-marine-engineers-and-naval-architects.html
+++ b/wiki/1-21-marine-engineers-and-naval-architects.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Marine Engineer, Naval Architect, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Shipbuilding">
   <link rel="canonical" href="https://tying.ai/wiki/1-21-marine-engineers-and-naval-architects.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Marine Engineers and Naval Architects: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Marine Engineer and Naval Architect career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-21-marine-engineers-and-naval-architects.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Marine Engineers and Naval Architects: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Marine Engineer and Naval Architect career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-22-materials-engineers.html
+++ b/wiki/1-22-materials-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Materials Engineer, Materials Science, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Metallurgy, Polymers, Ceramics">
   <link rel="canonical" href="https://tying.ai/wiki/1-22-materials-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Materials Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Materials Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-22-materials-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Materials Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Materials Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-23-mechanical-engineering-technologists-and-technicians.html
+++ b/wiki/1-23-mechanical-engineering-technologists-and-technicians.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Mechanical Engineering Technologist, Mechanical Engineering Technician, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Mechanical Design">
   <link rel="canonical" href="https://tying.ai/wiki/1-23-mechanical-engineering-technologists-and-technicians.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Mechanical Engineering Technologists and Technicians: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Mechanical Engineering Technologist and Technician career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-23-mechanical-engineering-technologists-and-technicians.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Mechanical Engineering Technologists and Technicians: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Mechanical Engineering Technologist and Technician career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-24-mechanical-engineers.html
+++ b/wiki/1-24-mechanical-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Mechanical Engineer, Mechanical Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Machine Design">
   <link rel="canonical" href="https://tying.ai/wiki/1-24-mechanical-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Mechanical Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Mechanical Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-24-mechanical-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Mechanical Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Mechanical Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-25-mining-and-geological-engineers.html
+++ b/wiki/1-25-mining-and-geological-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Mining Engineer, Geological Engineer, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Mining, Geology">
   <link rel="canonical" href="https://tying.ai/wiki/1-25-mining-and-geological-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Mining and Geological Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Mining and Geological Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-25-mining-and-geological-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Mining and Geological Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Mining and Geological Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-26-nuclear-engineers.html
+++ b/wiki/1-26-nuclear-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Nuclear Engineer, Nuclear Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Nuclear Power">
   <link rel="canonical" href="https://tying.ai/wiki/1-26-nuclear-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Nuclear Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Nuclear Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-26-nuclear-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Nuclear Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Nuclear Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-27-petroleum-engineers.html
+++ b/wiki/1-27-petroleum-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Petroleum Engineer, Petroleum Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Oil and Gas">
   <link rel="canonical" href="https://tying.ai/wiki/1-27-petroleum-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Petroleum Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Petroleum Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-27-petroleum-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Petroleum Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Petroleum Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-28-surveying-and-mapping-technicians.html
+++ b/wiki/1-28-surveying-and-mapping-technicians.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Surveying Technician, Mapping Technician, Career, Salary, Job Outlook, Skills, How to Become, Surveying, GIS, Cartography">
   <link rel="canonical" href="https://tying.ai/wiki/1-28-surveying-and-mapping-technicians.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Surveying and Mapping Technicians: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Surveying and Mapping Technician career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-28-surveying-and-mapping-technicians.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Surveying and Mapping Technicians: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Surveying and Mapping Technician career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-29-surveyors.html
+++ b/wiki/1-29-surveyors.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Surveyor, Land Surveyor, Career, Salary, Job Outlook, Skills, How to Become, Surveying, Geomatics, Boundary Survey">
   <link rel="canonical" href="https://tying.ai/wiki/1-29-surveyors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Surveyors: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Surveyor career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-29-surveyors.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Surveyors: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Surveyor career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-3-agricultural-engineers.html
+++ b/wiki/1-3-agricultural-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Agricultural Engineer, Agricultural Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Food Production, Environmental Engineering">
   <link rel="canonical" href="https://tying.ai/wiki/1-3-agricultural-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Agricultural Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Agricultural Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-3-agricultural-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Agricultural Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Agricultural Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-4-architects.html
+++ b/wiki/1-4-architects.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Architect, Architecture, Career, Salary, Job Outlook, Skills, How to Become, Design Jobs, Construction, Building Design">
   <link rel="canonical" href="https://tying.ai/wiki/1-4-architects.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Architects: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Architect career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-4-architects.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Architects: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Architect career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-5-bioengineers-and-biomedical-engineers.html
+++ b/wiki/1-5-bioengineers-and-biomedical-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Bioengineer, Biomedical Engineer, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Medical Devices, Biotechnology">
   <link rel="canonical" href="https://tying.ai/wiki/1-5-bioengineers-and-biomedical-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Bioengineers and Biomedical Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Bioengineer and Biomedical Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-5-bioengineers-and-biomedical-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Bioengineers and Biomedical Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Bioengineer and Biomedical Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-6-cartographers-and-photogrammetrists.html
+++ b/wiki/1-6-cartographers-and-photogrammetrists.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Cartographer, Photogrammetrist, Career, Salary, Job Outlook, Skills, How to Become, Mapping, GIS, Surveying">
   <link rel="canonical" href="https://tying.ai/wiki/1-6-cartographers-and-photogrammetrists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Cartographers and Photogrammetrists: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Cartographer and Photogrammetrist career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-6-cartographers-and-photogrammetrists.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cartographers and Photogrammetrists: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Cartographer and Photogrammetrist career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-7-chemical-engineers.html
+++ b/wiki/1-7-chemical-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Chemical Engineer, Chemical Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Process Engineering">
   <link rel="canonical" href="https://tying.ai/wiki/1-7-chemical-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Chemical Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Chemical Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-7-chemical-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Chemical Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Chemical Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-8-civil-engineering-technologists-and-technicians.html
+++ b/wiki/1-8-civil-engineering-technologists-and-technicians.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Civil Engineering Technologist, Civil Engineering Technician, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Construction">
   <link rel="canonical" href="https://tying.ai/wiki/1-8-civil-engineering-technologists-and-technicians.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Civil Engineering Technologists and Technicians: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Civil Engineering Technologist and Technician career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-8-civil-engineering-technologists-and-technicians.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Civil Engineering Technologists and Technicians: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Civil Engineering Technologist and Technician career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/1-9-civil-engineers.html
+++ b/wiki/1-9-civil-engineers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Civil Engineer, Civil Engineering, Career, Salary, Job Outlook, Skills, How to Become, Engineering Jobs, STEM Careers, Infrastructure, Construction">
   <link rel="canonical" href="https://tying.ai/wiki/1-9-civil-engineers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Civil Engineers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Civil Engineer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/1-9-civil-engineers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Civil Engineers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Civil Engineer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/2-1-art-directors.html
+++ b/wiki/2-1-art-directors.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Art Director, Creative Director, Career, Salary, Job Outlook, Skills, How to Become, Design, Advertising, Media">
   <link rel="canonical" href="https://tying.ai/wiki/2-1-art-directors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Art Directors: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Art Director career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/2-1-art-directors.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Art Directors: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Art Director career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/2.10-merchandise-displayers-and-window-trimmers.html
+++ b/wiki/2.10-merchandise-displayers-and-window-trimmers.html
@@ -6,14 +6,19 @@
     <title>Merchandise Displayers and Window Trimmers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Merchandise Displayers and Window Trimmers, who plan and erect commercial displays, such as in windows and interiors of retail stores.">
     <meta name="keywords" content="Merchandise Displayers, Window Trimmers, Visual Merchandising, Retail Design, 商品陈列员, 橱窗设计员, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.10-merchandise-displayers-and-window-trimmers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.10-merchandise-displayers-and-window-trimmers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Merchandise Displayers and Window Trimmers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Merchandise Displayers and Window Trimmers, who create visually appealing displays for retail stores.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.10-merchandise-displayers-and-window-trimmers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.10-merchandise-displayers-and-window-trimmers.html">
     <meta property="og:image" content="https://tying.ai/images/merchandise-displayers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Merchandise Displayers and Window Trimmers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Merchandise Displayers and Window Trimmers, who create visually appealing displays for retail stores.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.11-set-and-exhibit-designers.html
+++ b/wiki/2.11-set-and-exhibit-designers.html
@@ -6,14 +6,19 @@
     <title>Set and Exhibit Designers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Set and Exhibit Designers, who design and create sets for movie, television, and theater productions, as well as exhibits for museums and trade shows.">
     <meta name="keywords" content="Set Designers, Exhibit Designers, Production Design, Theater Design, Museum Exhibits, 场景设计师, 展览设计师, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.11-set-and-exhibit-designers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.11-set-and-exhibit-designers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Set and Exhibit Designers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Set and Exhibit Designers, who create sets and exhibits for productions, museums, and trade shows.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.11-set-and-exhibit-designers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.11-set-and-exhibit-designers.html">
     <meta property="og:image" content="https://tying.ai/images/set-designers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Set and Exhibit Designers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Set and Exhibit Designers, who create sets and exhibits for productions, museums, and trade shows.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.12-entertainment-and-performing-arts-occupations.html
+++ b/wiki/2.12-entertainment-and-performing-arts-occupations.html
@@ -6,14 +6,19 @@
     <title>Entertainment and Performing Arts Occupations - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of the Entertainment and Performing Arts Occupations category, which includes actors, directors, musicians, dancers, and other performers.">
     <meta name="keywords" content="Entertainment, Performing Arts, Actors, Directors, Musicians, Dancers, 娱乐, 表演艺术, 职业, occupation, career">
-    <link rel="canonical" href="https://tying.ai/wiki/2.12-entertainment-and-performing-arts-occupations">
+    <link rel="canonical" href="https://tying.ai/wiki/2.12-entertainment-and-performing-arts-occupations.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Entertainment and Performing Arts Occupations - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of the Entertainment and Performing Arts Occupations category.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.12-entertainment-and-performing-arts-occupations">
+    <meta property="og:url" content="https://tying.ai/wiki/2.12-entertainment-and-performing-arts-occupations.html">
     <meta property="og:image" content="https://tying.ai/images/performing-arts.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Entertainment and Performing Arts Occupations - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of the Entertainment and Performing Arts Occupations category.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.13-actors.html
+++ b/wiki/2.13-actors.html
@@ -6,14 +6,19 @@
     <title>Actors - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Actors, who portray characters in productions for stage, screen, television, and radio.">
     <meta name="keywords" content="Actors, Acting, Performers, Stage, Film, Television, 演员, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.13-actors">
+    <link rel="canonical" href="https://tying.ai/wiki/2.13-actors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Actors - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Actors, who portray characters in productions for stage, screen, television, and radio.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.13-actors">
+    <meta property="og:url" content="https://tying.ai/wiki/2.13-actors.html">
     <meta property="og:image" content="https://tying.ai/images/actors.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Actors - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Actors, who portray characters in productions for stage, screen, television, and radio.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.14-producers-and-directors.html
+++ b/wiki/2.14-producers-and-directors.html
@@ -6,14 +6,19 @@
     <title>Producers and Directors - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Producers and Directors, the key figures who oversee and manage the creative and financial aspects of theatrical, television, film, and other productions.">
     <meta name="keywords" content="Producers, Directors, Film Production, Theater, Television, 制片人, 导演, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.14-producers-and-directors">
+    <link rel="canonical" href="https://tying.ai/wiki/2.14-producers-and-directors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Producers and Directors - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Producers and Directors, who oversee the creative and financial aspects of productions.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.14-producers-and-directors">
+    <meta property="og:url" content="https://tying.ai/wiki/2.14-producers-and-directors.html">
     <meta property="og:image" content="https://tying.ai/images/producers-directors.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Producers and Directors - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Producers and Directors, who oversee the creative and financial aspects of productions.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.15-dancers.html
+++ b/wiki/2.15-dancers.html
@@ -6,14 +6,19 @@
     <title>Dancers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Dancers, who use movement to express ideas and stories in performances.">
     <meta name="keywords" content="Dancers, Dance, Performing Arts, Ballet, Modern Dance, 舞蹈家, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.15-dancers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.15-dancers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Dancers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Dancers, who use movement to express ideas and stories in performances.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.15-dancers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.15-dancers.html">
     <meta property="og:image" content="https://tying.ai/images/dancers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Dancers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Dancers, who use movement to express ideas and stories in performances.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.16-choreographers.html
+++ b/wiki/2.16-choreographers.html
@@ -6,14 +6,19 @@
     <title>Choreographers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Choreographers, who design and direct dance movements for performances.">
     <meta name="keywords" content="Choreographers, Choreography, Dance, Performing Arts, 编舞家, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.16-choreographers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.16-choreographers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Choreographers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Choreographers, who design and direct dance movements for performances.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.16-choreographers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.16-choreographers.html">
     <meta property="og:image" content="https://tying.ai/images/choreographers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Choreographers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Choreographers, who design and direct dance movements for performances.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.17-music-directors-and-composers.html
+++ b/wiki/2.17-music-directors-and-composers.html
@@ -6,14 +6,19 @@
     <title>Music Directors and Composers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Music Directors and Composers, who conduct, direct, plan, and lead instrumental or vocal performances, or create original music.">
     <meta name="keywords" content="Music Directors, Composers, Conductors, Songwriters, 音乐总监, 作曲家, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.17-music-directors-and-composers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.17-music-directors-and-composers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Music Directors and Composers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Music Directors and Composers, who lead performances or create original music.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.17-music-directors-and-composers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.17-music-directors-and-composers.html">
     <meta property="og:image" content="https://tying.ai/images/music-directors-composers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Music Directors and Composers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Music Directors and Composers, who lead performances or create original music.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.18-musicians-and-singers.html
+++ b/wiki/2.18-musicians-and-singers.html
@@ -6,14 +6,19 @@
     <title>Musicians and Singers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Musicians and Singers, who play instruments or sing to perform music for audiences.">
     <meta name="keywords" content="Musicians, Singers, Vocalists, Instrumentalists, Performing Arts, 音乐家, 歌手, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.18-musicians-and-singers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.18-musicians-and-singers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Musicians and Singers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Musicians and Singers, who play instruments or sing to perform music for audiences.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.18-musicians-and-singers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.18-musicians-and-singers.html">
     <meta property="og:image" content="https://tying.ai/images/musicians-singers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Musicians and Singers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Musicians and Singers, who play instruments or sing to perform music for audiences.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.19-entertainers-performers-and-sports-workers.html
+++ b/wiki/2.19-entertainers-performers-and-sports-workers.html
@@ -6,14 +6,19 @@
     <title>Entertainers, Performers, and Sports Workers, All Other - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of miscellaneous entertainers, performers, and sports-related workers not classified elsewhere, such as clowns, magicians, and professional athletes.">
     <meta name="keywords" content="Entertainers, Performers, Athletes, Sports Workers, Magicians, Comedians, 艺人, 表演者, 体育工作者, occupation, career, job description">
-    <link rel="canonical" href="https://tying.ai/wiki/2.19-entertainers-performers-and-sports-workers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.19-entertainers-performers-and-sports-workers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Entertainers, Performers, and Sports Workers, All Other - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of miscellaneous entertainers, performers, and sports-related workers.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.19-entertainers-performers-and-sports-workers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.19-entertainers-performers-and-sports-workers.html">
     <meta property="og:image" content="https://tying.ai/images/misc-performers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Entertainers, Performers, and Sports Workers, All Other - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of miscellaneous entertainers, performers, and sports-related workers.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.2-craft-artists.html
+++ b/wiki/2.2-craft-artists.html
@@ -6,14 +6,19 @@
     <title>Craft Artists - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Craft Artists, including job description, career path, and market trends.">
     <meta name="keywords" content="Craft Artists, 工艺美术师, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.2-craft-artists">
+    <link rel="canonical" href="https://tying.ai/wiki/2.2-craft-artists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Craft Artists - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Craft Artists, including job description, career path, and market trends.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.2-craft-artists">
+    <meta property="og:url" content="https://tying.ai/wiki/2.2-craft-artists.html">
     <meta property="og:image" content="https://tying.ai/images/craft-artists.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Craft Artists - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Craft Artists, including job description, career path, and market trends.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.20-media-and-communication-equipment-workers.html
+++ b/wiki/2.20-media-and-communication-equipment-workers.html
@@ -6,14 +6,19 @@
     <title>Media and Communication Equipment Workers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of the Media and Communication Equipment Workers category, which includes technicians who operate and maintain the equipment for media productions.">
     <meta name="keywords" content="Media, Communication, Equipment, Technicians, Audio, Video, Broadcast, Camera, 媒体, 通讯, 设备, 从业员, occupation, career">
-    <link rel="canonical" href="https://tying.ai/wiki/2.20-media-and-communication-equipment-workers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.20-media-and-communication-equipment-workers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Media and Communication Equipment Workers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of the Media and Communication Equipment Workers category.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.20-media-and-communication-equipment-workers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.20-media-and-communication-equipment-workers.html">
     <meta property="og:image" content="https://tying.ai/images/media-equipment.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Media and Communication Equipment Workers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of the Media and Communication Equipment Workers category.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.21-audio-and-video-technicians.html
+++ b/wiki/2.21-audio-and-video-technicians.html
@@ -6,14 +6,19 @@
     <title>Audio and Video Technicians - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Audio and Video Technicians, who set up, operate, and maintain equipment for recording and broadcasting sound and video.">
     <meta name="keywords" content="Audio Technicians, Video Technicians, AV Tech, Live Sound, Broadcast, 音频技术员, 视频技术员, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.21-audio-and-video-technicians">
+    <link rel="canonical" href="https://tying.ai/wiki/2.21-audio-and-video-technicians.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Audio and Video Technicians - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Audio and Video Technicians, who manage sound and video for various productions.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.21-audio-and-video-technicians">
+    <meta property="og:url" content="https://tying.ai/wiki/2.21-audio-and-video-technicians.html">
     <meta property="og:image" content="https://tying.ai/images/av-techs.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Audio and Video Technicians - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Audio and Video Technicians, who manage sound and video for various productions.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.22-lighting-technicians-and-other-media-workers.html
+++ b/wiki/2.22-lighting-technicians-and-other-media-workers.html
@@ -6,14 +6,19 @@
     <title>Lighting Technicians and Other Media Equipment Workers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Lighting Technicians and other miscellaneous media and communication equipment workers not classified elsewhere.">
     <meta name="keywords" content="Lighting Technicians, Media Equipment, Communication Equipment, Stage Lighting, Grip, 灯光技术员, 媒体设备员, occupation, career, job description">
-    <link rel="canonical" href="https://tying.ai/wiki/2.22-lighting-technicians-and-other-media-workers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.22-lighting-technicians-and-other-media-workers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Lighting Technicians and Other Media Equipment Workers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Lighting Technicians and other miscellaneous media and communication equipment workers.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.22-lighting-technicians-and-other-media-workers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.22-lighting-technicians-and-other-media-workers.html">
     <meta property="og:image" content="https://tying.ai/images/lighting-techs.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Lighting Technicians and Other Media Equipment Workers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Lighting Technicians and other miscellaneous media and communication equipment workers.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.3-fine-artists.html
+++ b/wiki/2.3-fine-artists.html
@@ -6,14 +6,19 @@
     <title>Fine Artists - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Fine Artists, including painters, sculptors, and illustrators, detailing their job description, career path, and market trends.">
     <meta name="keywords" content="Fine Artists, Painters, Sculptors, Illustrators, 美术家, 画家, 雕塑家, 插画家, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.3-fine-artists">
+    <link rel="canonical" href="https://tying.ai/wiki/2.3-fine-artists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Fine Artists - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Fine Artists, including painters, sculptors, and illustrators, detailing their job description, career path, and market trends.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.3-fine-artists">
+    <meta property="og:url" content="https://tying.ai/wiki/2.3-fine-artists.html">
     <meta property="og:image" content="https://tying.ai/images/fine-artists.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fine Artists - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Fine Artists, including painters, sculptors, and illustrators, detailing their job description, career path, and market trends.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.4-special-effects-artists-and-animators.html
+++ b/wiki/2.4-special-effects-artists-and-animators.html
@@ -6,14 +6,19 @@
     <title>Special Effects Artists and Animators - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Special Effects Artists and Animators, including their job description, career path, and market trends in film, television, and video games.">
     <meta name="keywords" content="Special Effects Artists, Animators, VFX, CGI, Motion Graphics, 特效艺术家, 动画师, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.4-special-effects-artists-and-animators">
+    <link rel="canonical" href="https://tying.ai/wiki/2.4-special-effects-artists-and-animators.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Special Effects Artists and Animators - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Special Effects Artists and Animators, including their job description, career path, and market trends.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.4-special-effects-artists-and-animators">
+    <meta property="og:url" content="https://tying.ai/wiki/2.4-special-effects-artists-and-animators.html">
     <meta property="og:image" content="https://tying.ai/images/sfx-animators.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Special Effects Artists and Animators - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Special Effects Artists and Animators, including their job description, career path, and market trends.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.5-commercial-and-industrial-designers.html
+++ b/wiki/2.5-commercial-and-industrial-designers.html
@@ -6,14 +6,19 @@
     <title>Commercial and Industrial Designers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Commercial and Industrial Designers, detailing their job description, career path, and market trends.">
     <meta name="keywords" content="Commercial and Industrial Designers, Product Design, Industrial Design, 商业和工业设计师, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.5-commercial-and-industrial-designers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.5-commercial-and-industrial-designers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Commercial and Industrial Designers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Commercial and Industrial Designers, detailing their job description, career path, and market trends.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.5-commercial-and-industrial-designers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.5-commercial-and-industrial-designers.html">
     <meta property="og:image" content="https://tying.ai/images/industrial-designers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Commercial and Industrial Designers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Commercial and Industrial Designers, detailing their job description, career path, and market trends.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.6-fashion-designers.html
+++ b/wiki/2.6-fashion-designers.html
@@ -6,14 +6,19 @@
     <title>Fashion Designers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Fashion Designers, detailing their work, career path, and the dynamic trends in the fashion industry.">
     <meta name="keywords" content="Fashion Designers, Apparel Design, Haute Couture, Ready-to-wear, 时装设计师, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.6-fashion-designers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.6-fashion-designers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Fashion Designers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Fashion Designers, detailing their work, career path, and the dynamic trends in the fashion industry.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.6-fashion-designers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.6-fashion-designers.html">
     <meta property="og:image" content="https://tying.ai/images/fashion-designers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fashion Designers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Fashion Designers, detailing their work, career path, and the dynamic trends in the fashion industry.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.7-floral-designers.html
+++ b/wiki/2.7-floral-designers.html
@@ -6,14 +6,19 @@
     <title>Floral Designers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Floral Designers, covering their job description, work environment, and career path in creating arrangements with flowers.">
     <meta name="keywords" content="Floral Designers, Florist, Flower Arrangements, 花艺设计师, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.7-floral-designers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.7-floral-designers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Floral Designers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Floral Designers, covering their job description, work environment, and career path.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.7-floral-designers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.7-floral-designers.html">
     <meta property="og:image" content="https://tying.ai/images/floral-designers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Floral Designers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Floral Designers, covering their job description, work environment, and career path.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.8-graphic-designers.html
+++ b/wiki/2.8-graphic-designers.html
@@ -6,14 +6,19 @@
     <title>Graphic Designers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Graphic Designers, detailing their role in creating visual concepts for branding, advertising, and digital media.">
     <meta name="keywords" content="Graphic Designers, Visual Communication, Branding, UI/UX, 平面设计师, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.8-graphic-designers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.8-graphic-designers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Graphic Designers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Graphic Designers, detailing their role in creating visual concepts for branding, advertising, and digital media.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.8-graphic-designers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.8-graphic-designers.html">
     <meta property="og:image" content="https://tying.ai/images/graphic-designers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Graphic Designers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Graphic Designers, detailing their role in creating visual concepts for branding, advertising, and digital media.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/2.9-interior-designers.html
+++ b/wiki/2.9-interior-designers.html
@@ -6,14 +6,19 @@
     <title>Interior Designers - Encyclopedia of Occupations</title>
     <meta name="description" content="An overview of Interior Designers, who make indoor spaces functional, safe, and beautiful by determining space requirements and selecting essential and decorative items.">
     <meta name="keywords" content="Interior Designers, Interior Decorator, Space Planning, 室内设计师, occupation, career, job description, skills, salary, market trends">
-    <link rel="canonical" href="https://tying.ai/wiki/2.9-interior-designers">
+    <link rel="canonical" href="https://tying.ai/wiki/2.9-interior-designers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Interior Designers - Encyclopedia of Occupations">
     <meta property="og:description" content="An overview of Interior Designers, who make indoor spaces functional, safe, and beautiful.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://tying.ai/wiki/2.9-interior-designers">
+    <meta property="og:url" content="https://tying.ai/wiki/2.9-interior-designers.html">
     <meta property="og:image" content="https://tying.ai/images/interior-designers.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Interior Designers - Encyclopedia of Occupations">
+  <meta name="twitter:description" content="An overview of Interior Designers, who make indoor spaces functional, safe, and beautiful.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/wiki/3-1-grounds-maintenance-workers.html
+++ b/wiki/3-1-grounds-maintenance-workers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Grounds Maintenance Worker, Landscaping, Groundskeeper, Career, Salary, Job Outlook, Skills, How to Become, Outdoor Jobs">
   <link rel="canonical" href="https://tying.ai/wiki/3-1-grounds-maintenance-workers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Grounds Maintenance Workers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Grounds Maintenance Worker career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/3-1-grounds-maintenance-workers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grounds Maintenance Workers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Grounds Maintenance Worker career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/3-2-janitors-and-building-cleaners.html
+++ b/wiki/3-2-janitors-and-building-cleaners.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Janitor, Building Cleaner, Custodian, Career, Salary, Job Outlook, Skills, How to Become, Cleaning Services">
   <link rel="canonical" href="https://tying.ai/wiki/3-2-janitors-and-building-cleaners.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Janitors and Building Cleaners: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Janitor and Building Cleaner career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/3-2-janitors-and-building-cleaners.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Janitors and Building Cleaners: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Janitor and Building Cleaner career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/3-3-pest-control-workers.html
+++ b/wiki/3-3-pest-control-workers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Pest Control Worker, Exterminator, Pest Management, Career, Salary, Job Outlook, Skills, How to Become, Public Health">
   <link rel="canonical" href="https://tying.ai/wiki/3-3-pest-control-workers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Pest Control Workers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Pest Control Worker career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/3-3-pest-control-workers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Pest Control Workers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Pest Control Worker career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-1-accountants-and-auditors.html
+++ b/wiki/4-1-accountants-and-auditors.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Accountant, Auditor, CPA, Career, Salary, Job Outlook, Skills, How to Become, Finance Jobs, Accounting">
   <link rel="canonical" href="https://tying.ai/wiki/4-1-accountants-and-auditors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Accountants and Auditors: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Accountant and Auditor career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-1-accountants-and-auditors.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Accountants and Auditors: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Accountant and Auditor career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-10-fundraisers.html
+++ b/wiki/4-10-fundraisers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Fundraiser, Development Officer, Philanthropy, Nonprofit, Career, Salary, Job Outlook, Skills, How to Become, Advancement">
   <link rel="canonical" href="https://tying.ai/wiki/4-10-fundraisers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Fundraisers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Fundraiser career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-10-fundraisers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fundraisers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Fundraiser career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-11-human-resources-specialists.html
+++ b/wiki/4-11-human-resources-specialists.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Human Resources Specialist, HR Generalist, Recruiter, Career, Salary, Job Outlook, Skills, How to Become, SHRM">
   <link rel="canonical" href="https://tying.ai/wiki/4-11-human-resources-specialists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Human Resources Specialists: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Human Resources Specialist career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-11-human-resources-specialists.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Human Resources Specialists: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Human Resources Specialist career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-12-insurance-underwriters.html
+++ b/wiki/4-12-insurance-underwriters.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Insurance Underwriter, Underwriting, Risk Assessment, Career, Salary, Job Outlook, Skills, How to Become, Insurance, CPCU">
   <link rel="canonical" href="https://tying.ai/wiki/4-12-insurance-underwriters.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Insurance Underwriters: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Insurance Underwriter career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-12-insurance-underwriters.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Insurance Underwriters: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Insurance Underwriter career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-13-labor-relations-specialists.html
+++ b/wiki/4-13-labor-relations-specialists.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Labor Relations Specialists, Labor Contracts, Collective Bargaining, Grievance Resolution, Labor Law, Human Resources, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-13-labor-relations-specialists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Labor Relations Specialists | Tying AI">
     <meta property="og:description" content="Explore the world of Labor Relations Specialists, a career focused on interpreting and administering labor contracts, resolving grievances, and fostering positive relationships between labor and management.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-13-labor-relations-specialists.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Labor Relations Specialists | Tying AI">
+  <meta name="twitter:description" content="Explore the world of Labor Relations Specialists, a career focused on interpreting and administering labor contracts, resolving grievances, and fostering positive relationships between labor and management.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-13-labor-relations-specialists.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-14-loan-officers.html
+++ b/wiki/4-14-loan-officers.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Loan Officers, Loan Application, Credit Analysis, Financial Services, Mortgage Loans, Commercial Loans, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-14-loan-officers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Loan Officers | Tying AI">
     <meta property="og:description" content="Discover the role of Loan Officers, financial professionals who evaluate, authorize, or recommend approval of loan applications for individuals and businesses.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-14-loan-officers.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Loan Officers | Tying AI">
+  <meta name="twitter:description" content="Discover the role of Loan Officers, financial professionals who evaluate, authorize, or recommend approval of loan applications for individuals and businesses.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-14-loan-officers.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-15-logisticians.html
+++ b/wiki/4-15-logisticians.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Logisticians, Supply Chain Management, Logistics, Distribution, Warehouse Management, Procurement, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-15-logisticians.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Logisticians | Tying AI">
     <meta property="og:description" content="Learn about Logisticians, the professionals who analyze and coordinate an organization's supply chain to move products efficiently from supplier to consumer.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-15-logisticians.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Logisticians | Tying AI">
+  <meta name="twitter:description" content="Learn about Logisticians, the professionals who analyze and coordinate an organization's supply chain to move products efficiently from supplier to consumer.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-15-logisticians.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-16-management-analysts.html
+++ b/wiki/4-16-management-analysts.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Management Analysts, Management Consultant, Business Consulting, Organizational Efficiency, Process Improvement, Business Strategy, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-16-management-analysts.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Management Analysts | Tying AI">
     <meta property="og:description" content="Explore the career of Management Analysts, also known as management consultants, who advise organizations on how to improve their efficiency, profitability, and overall performance.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-16-management-analysts.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Management Analysts | Tying AI">
+  <meta name="twitter:description" content="Explore the career of Management Analysts, also known as management consultants, who advise organizations on how to improve their efficiency, profitability, and overall performance.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-16-management-analysts.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-17-market-research-analysts.html
+++ b/wiki/4-17-market-research-analysts.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Market Research Analysts, Market Analysis, Consumer Behavior, Data Analysis, Marketing Strategy, Surveys, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-17-market-research-analysts.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Market Research Analysts | Tying AI">
     <meta property="og:description" content="Learn about Market Research Analysts, professionals who study market conditions to examine potential sales of a product or service and help companies understand consumer behavior.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-17-market-research-analysts.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Market Research Analysts | Tying AI">
+  <meta name="twitter:description" content="Learn about Market Research Analysts, professionals who study market conditions to examine potential sales of a product or service and help companies understand consumer behavior.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-17-market-research-analysts.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-18-meeting-convention-and-event-planners.html
+++ b/wiki/4-18-meeting-convention-and-event-planners.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Event Planners, Meeting Planners, Convention Planners, Event Management, Corporate Events, Wedding Planning, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-18-meeting-convention-and-event-planners.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Meeting, Convention, and Event Planners | Tying AI">
     <meta property="og:description" content="Discover the dynamic world of Meeting, Convention, and Event Planners, who coordinate all aspects of professional meetings and events, from small gatherings to large-scale conventions.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-18-meeting-convention-and-event-planners.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Meeting, Convention, and Event Planners | Tying AI">
+  <meta name="twitter:description" content="Discover the dynamic world of Meeting, Convention, and Event Planners, who coordinate all aspects of professional meetings and events, from small gatherings to large-scale conventions.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-18-meeting-convention-and-event-planners.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-19-personal-financial-advisors.html
+++ b/wiki/4-19-personal-financial-advisors.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Personal Financial Advisors, Financial Planning, Investment Management, Retirement Planning, Wealth Management, Certified Financial Planner, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-19-personal-financial-advisors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Personal Financial Advisors | Tying AI">
     <meta property="og:description" content="Understand the role of Personal Financial Advisors, who provide expert advice to help individuals manage their finances, plan for retirement, and make sound investment decisions.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-19-personal-financial-advisors.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Personal Financial Advisors | Tying AI">
+  <meta name="twitter:description" content="Understand the role of Personal Financial Advisors, who provide expert advice to help individuals manage their finances, plan for retirement, and make sound investment decisions.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-19-personal-financial-advisors.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-2-budget-analysts.html
+++ b/wiki/4-2-budget-analysts.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Budget Analyst, Financial Planning, Budgeting, Career, Salary, Job Outlook, Skills, How to Become, Finance Jobs">
   <link rel="canonical" href="https://tying.ai/wiki/4-2-budget-analysts.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Budget Analysts: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Budget Analyst career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-2-budget-analysts.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Budget Analysts: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Budget Analyst career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-20-project-management-specialists.html
+++ b/wiki/4-20-project-management-specialists.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Project Management Specialists, Project Manager, PMP, Agile, Scrum, Project Planning, Risk Management, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-20-project-management-specialists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Project Management Specialists | Tying AI">
     <meta property="og:description" content="Learn about Project Management Specialists, the professionals responsible for planning, executing, and closing projects to meet specific goals within a set timeframe and budget.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-20-project-management-specialists.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Project Management Specialists | Tying AI">
+  <meta name="twitter:description" content="Learn about Project Management Specialists, the professionals responsible for planning, executing, and closing projects to meet specific goals within a set timeframe and budget.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-20-project-management-specialists.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-21-property-appraisers-and-assessors.html
+++ b/wiki/4-21-property-appraisers-and-assessors.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Property Appraiser, Property Assessor, Real Estate Valuation, Property Tax, Appraisal, Real Property, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-21-property-appraisers-and-assessors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Property Appraisers and Assessors | Tying AI">
     <meta property="og:description" content="Learn about Property Appraisers and Assessors, the professionals who estimate the value of real property for purposes like sales, property taxes, and development.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-21-property-appraisers-and-assessors.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Property Appraisers and Assessors | Tying AI">
+  <meta name="twitter:description" content="Learn about Property Appraisers and Assessors, the professionals who estimate the value of real property for purposes like sales, property taxes, and development.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-21-property-appraisers-and-assessors.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-22-purchasing-managers-buyers-and-purchasing-agents.html
+++ b/wiki/4-22-purchasing-managers-buyers-and-purchasing-agents.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Purchasing Manager, Buyer, Purchasing Agent, Procurement, Supply Chain, Negotiation, Vendor Management, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-22-purchasing-managers-buyers-and-purchasing-agents.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Purchasing Managers, Buyers, and Purchasing Agents | Tying AI">
     <meta property="og:description" content="Explore the roles of Purchasing Managers, Buyers, and Purchasing Agents, who are responsible for buying the products and services an organization needs to operate.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-22-purchasing-managers-buyers-and-purchasing-agents.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Purchasing Managers, Buyers, and Purchasing Agents | Tying AI">
+  <meta name="twitter:description" content="Explore the roles of Purchasing Managers, Buyers, and Purchasing Agents, who are responsible for buying the products and services an organization needs to operate.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-22-purchasing-managers-buyers-and-purchasing-agents.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-23-tax-examiners-and-collectors-and-revenue-agents.html
+++ b/wiki/4-23-tax-examiners-and-collectors-and-revenue-agents.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Tax Examiner, Tax Collector, Revenue Agent, IRS, Tax Compliance, Tax Audit, Government Finance, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-23-tax-examiners-and-collectors-and-revenue-agents.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Tax Examiners and Collectors, and Revenue Agents | Tying AI">
     <meta property="og:description" content="Learn about the roles of Tax Examiners, Collectors, and Revenue Agents, government professionals who ensure that federal, state, and local taxes are paid correctly and on time.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-23-tax-examiners-and-collectors-and-revenue-agents.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Tax Examiners and Collectors, and Revenue Agents | Tying AI">
+  <meta name="twitter:description" content="Learn about the roles of Tax Examiners, Collectors, and Revenue Agents, government professionals who ensure that federal, state, and local taxes are paid correctly and on time.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-23-tax-examiners-and-collectors-and-revenue-agents.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-24-training-and-development-specialists.html
+++ b/wiki/4-24-training-and-development-specialists.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Training and Development, Corporate Trainer, Instructional Design, Employee Learning, Talent Development, Human Resources, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/4-24-training-and-development-specialists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Training and Development Specialists | Tying AI">
     <meta property="og:description" content="Learn about Training and Development Specialists, who plan, conduct, and administer programs that improve the skills and knowledge of an organization's employees.">
     <meta property="og:image" content="https://tying.ai/images/wiki/4-24-training-and-development-specialists.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Training and Development Specialists | Tying AI">
+  <meta name="twitter:description" content="Learn about Training and Development Specialists, who plan, conduct, and administer programs that improve the skills and knowledge of an organization's employees.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/4-24-training-and-development-specialists.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/4-3-claims-adjusters-appraisers-examiners-and-investigators.html
+++ b/wiki/4-3-claims-adjusters-appraisers-examiners-and-investigators.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Claims Adjuster, Insurance Appraiser, Claims Examiner, Insurance Investigator, Career, Salary, Job Outlook, Skills">
   <link rel="canonical" href="https://tying.ai/wiki/4-3-claims-adjusters-appraisers-examiners-and-investigators.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Claims Adjusters, Appraisers, Examiners, and Investigators: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to careers in claims adjusting, appraising, examining, and investigating." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-3-claims-adjusters-appraisers-examiners-and-investigators.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Claims Adjusters, Appraisers, Examiners, and Investigators: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to careers in claims adjusting, appraising, examining, and investigating.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-4-compensation-benefits-and-job-analysis-specialists.html
+++ b/wiki/4-4-compensation-benefits-and-job-analysis-specialists.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Compensation Specialist, Benefits Analyst, Job Analyst, Human Resources, HR, Career, Salary, Job Outlook, Skills">
   <link rel="canonical" href="https://tying.ai/wiki/4-4-compensation-benefits-and-job-analysis-specialists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Compensation, Benefits, and Job Analysis Specialists: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Compensation, Benefits, and Job Analysis Specialist career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-4-compensation-benefits-and-job-analysis-specialists.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Compensation, Benefits, and Job Analysis Specialists: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Compensation, Benefits, and Job Analysis Specialist career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-5-compliance-officers.html
+++ b/wiki/4-5-compliance-officers.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Compliance Officer, Regulatory Compliance, Risk Management, Career, Salary, Job Outlook, Skills, How to Become, Legal">
   <link rel="canonical" href="https://tying.ai/wiki/4-5-compliance-officers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Compliance Officers: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Compliance Officer career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-5-compliance-officers.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Compliance Officers: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Compliance Officer career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-6-cost-estimators.html
+++ b/wiki/4-6-cost-estimators.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Cost Estimator, Cost Engineering, Project Management, Career, Salary, Job Outlook, Skills, How to Become, Construction">
   <link rel="canonical" href="https://tying.ai/wiki/4-6-cost-estimators.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Cost Estimators: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Cost Estimator career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-6-cost-estimators.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cost Estimators: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Cost Estimator career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-7-credit-counselors.html
+++ b/wiki/4-7-credit-counselors.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Credit Counselor, Financial Counseling, Debt Management, Career, Salary, Job Outlook, Skills, How to Become, Personal Finance">
   <link rel="canonical" href="https://tying.ai/wiki/4-7-credit-counselors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Credit Counselors: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Credit Counselor career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-7-credit-counselors.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Credit Counselors: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Credit Counselor career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-8-financial-analysts.html
+++ b/wiki/4-8-financial-analysts.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Financial Analyst, Investment Analyst, CFA, Career, Salary, Job Outlook, Skills, How to Become, Finance Jobs, Equity Research">
   <link rel="canonical" href="https://tying.ai/wiki/4-8-financial-analysts.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Financial Analysts: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Financial Analyst career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-8-financial-analysts.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Financial Analysts: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Financial Analyst career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/4-9-financial-examiners.html
+++ b/wiki/4-9-financial-examiners.html
@@ -8,11 +8,17 @@
   <meta name="keywords" content="Financial Examiner, Bank Examiner, Regulatory, Career, Salary, Job Outlook, Skills, How to Become, Finance, Government Jobs">
   <link rel="canonical" href="https://tying.ai/wiki/4-9-financial-examiners.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
   <meta property="og:title" content="Financial Examiners: Career Encyclopedia" />
   <meta property="og:description" content="Comprehensive guide to the Financial Examiner career: salary, skills, job outlook, and more." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://tying.ai/wiki/4-9-financial-examiners.html" />
+  <meta property="og:image" content="https://tying.ai/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Financial Examiners: Career Encyclopedia">
+  <meta name="twitter:description" content="Comprehensive guide to the Financial Examiner career: salary, skills, job outlook, and more.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
   <meta property="og:site_name" content="Career Encyclopedia" />
   <script type="application/ld+json">
   {

--- a/wiki/5-1-community-health-workers.html
+++ b/wiki/5-1-community-health-workers.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Community Health Worker, Public Health, Health Education, Social Services, Healthcare Access, Patient Navigator, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/5-1-community-health-workers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Community Health Workers | Tying AI">
     <meta property="og:description" content="Learn about Community Health Workers, the frontline public health professionals who serve as a vital link between communities and healthcare services.">
     <meta property="og:image" content="https://tying.ai/images/wiki/5-1-community-health-workers.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Community Health Workers | Tying AI">
+  <meta name="twitter:description" content="Learn about Community Health Workers, the frontline public health professionals who serve as a vital link between communities and healthcare services.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/5-1-community-health-workers.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/5-2-health-education-specialists.html
+++ b/wiki/5-2-health-education-specialists.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Health Education Specialist, Public Health, Health Promotion, Wellness, Community Health, Certified Health Education Specialist, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/5-2-health-education-specialists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Health Education Specialists | Tying AI">
     <meta property="og:description" content="Discover the role of Health Education Specialists, professionals who develop and implement strategies to improve the health of individuals and communities.">
     <meta property="og:image" content="https://tying.ai/images/wiki/5-2-health-education-specialists.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Health Education Specialists | Tying AI">
+  <meta name="twitter:description" content="Discover the role of Health Education Specialists, professionals who develop and implement strategies to improve the health of individuals and communities.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/5-2-health-education-specialists.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/5-3-marriage-and-family-therapists.html
+++ b/wiki/5-3-marriage-and-family-therapists.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Marriage and Family Therapist, MFT, Psychotherapy, Family Therapy, Couples Counseling, Mental Health, Relationship Counseling, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/5-3-marriage-and-family-therapists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Marriage and Family Therapists | Tying AI">
     <meta property="og:description" content="Explore the profession of Marriage and Family Therapists (MFTs), who diagnose and treat mental and emotional disorders within the context of family systems.">
     <meta property="og:image" content="https://tying.ai/images/wiki/5-3-marriage-and-family-therapists.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Marriage and Family Therapists | Tying AI">
+  <meta name="twitter:description" content="Explore the profession of Marriage and Family Therapists (MFTs), who diagnose and treat mental and emotional disorders within the context of family systems.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/5-3-marriage-and-family-therapists.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/5-4-probation-officers-and-correctional-treatment-specialists.html
+++ b/wiki/5-4-probation-officers-and-correctional-treatment-specialists.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Probation Officer, Correctional Treatment Specialist, Criminal Justice, Rehabilitation, Case Management, Community Supervision, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/5-4-probation-officers-and-correctional-treatment-specialists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Probation Officers and Correctional Treatment Specialists | Tying AI">
     <meta property="og:description" content="Learn about Probation Officers and Correctional Treatment Specialists, who play a crucial role in the criminal justice system by supervising offenders and helping them reintegrate into society.">
     <meta property="og:image" content="https://tying.ai/images/wiki/5-4-probation-officers-and-correctional-treatment-specialists.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Probation Officers and Correctional Treatment Specialists | Tying AI">
+  <meta name="twitter:description" content="Learn about Probation Officers and Correctional Treatment Specialists, who play a crucial role in the criminal justice system by supervising offenders and helping them reintegrate into society.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/5-4-probation-officers-and-correctional-treatment-specialists.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/5-5-rehabilitation-counselors.html
+++ b/wiki/5-5-rehabilitation-counselors.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Rehabilitation Counselor, Vocational Rehabilitation, Disability Services, Counseling, Mental Health, Career Counseling, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/5-5-rehabilitation-counselors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Rehabilitation Counselors | Tying AI">
     <meta property="og:description" content="Learn about Rehabilitation Counselors, who help people with physical, mental, developmental, or emotional disabilities live independently and find employment.">
     <meta property="og:image" content="https://tying.ai/images/wiki/5-5-rehabilitation-counselors.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Rehabilitation Counselors | Tying AI">
+  <meta name="twitter:description" content="Learn about Rehabilitation Counselors, who help people with physical, mental, developmental, or emotional disabilities live independently and find employment.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/5-5-rehabilitation-counselors.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/5-6-school-and-career-counselors-and-advisors.html
+++ b/wiki/5-6-school-and-career-counselors-and-advisors.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="School Counselor, Career Counselor, Academic Advisor, College Planning, Student Development, Career Guidance, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/5-6-school-and-career-counselors-and-advisors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="School and Career Counselors and Advisors | Tying AI">
     <meta property="og:description" content="Learn about School and Career Counselors and Advisors, who help students develop academic and social skills and plan for their future careers.">
     <meta property="og:image" content="https://tying.ai/images/wiki/5-6-school-and-career-counselors-and-advisors.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="School and Career Counselors and Advisors | Tying AI">
+  <meta name="twitter:description" content="Learn about School and Career Counselors and Advisors, who help students develop academic and social skills and plan for their future careers.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/5-6-school-and-career-counselors-and-advisors.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/5-7-social-and-human-service-assistants.html
+++ b/wiki/5-7-social-and-human-service-assistants.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Social and Human Service Assistant, Case Worker Aide, Social Work Assistant, Community Support Worker, Human Services, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/5-7-social-and-human-service-assistants.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Social and Human Service Assistants | Tying AI">
     <meta property="og:description" content="Learn about Social and Human Service Assistants, who provide direct support to clients and assist social workers and other professionals in delivering services.">
     <meta property="og:image" content="https://tying.ai/images/wiki/5-7-social-and-human-service-assistants.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Social and Human Service Assistants | Tying AI">
+  <meta name="twitter:description" content="Learn about Social and Human Service Assistants, who provide direct support to clients and assist social workers and other professionals in delivering services.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/5-7-social-and-human-service-assistants.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/5-8-social-workers.html
+++ b/wiki/5-8-social-workers.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Social Worker, LCSW, Social Work, Case Management, Advocacy, Mental Health, Child Welfare, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/5-8-social-workers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Social Workers | Tying AI">
     <meta property="og:description" content="Explore the profession of Social Workers, who are dedicated to helping individuals, families, and groups cope with problems in their everyday lives and advocating for social justice.">
     <meta property="og:image" content="https://tying.ai/images/wiki/5-8-social-workers.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Social Workers | Tying AI">
+  <meta name="twitter:description" content="Explore the profession of Social Workers, who are dedicated to helping individuals, families, and groups cope with problems in their everyday lives and advocating for social justice.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/5-8-social-workers.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/5-9-substance-abuse-behavioral-disorder-and-mental-health-counselors.html
+++ b/wiki/5-9-substance-abuse-behavioral-disorder-and-mental-health-counselors.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Mental Health Counselor, Substance Abuse Counselor, Addiction Counselor, LPC, LMHC, Behavioral Health, Psychotherapy, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/5-9-substance-abuse-behavioral-disorder-and-mental-health-counselors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Substance Abuse, Behavioral Disorder, and Mental Health Counselors | Tying AI">
     <meta property="og:description" content="Learn about Substance Abuse, Behavioral Disorder, and Mental Health Counselors, who provide treatment and support to individuals struggling with addiction and mental health issues.">
     <meta property="og:image" content="https://tying.ai/images/wiki/5-9-substance-abuse-behavioral-disorder-and-mental-health-counselors.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Substance Abuse, Behavioral Disorder, and Mental Health Counselors | Tying AI">
+  <meta name="twitter:description" content="Learn about Substance Abuse, Behavioral Disorder, and Mental Health Counselors, who provide treatment and support to individuals struggling with addiction and mental health issues.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/5-9-substance-abuse-behavioral-disorder-and-mental-health-counselors.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/6-1-computer-and-information-research-scientists.html
+++ b/wiki/6-1-computer-and-information-research-scientists.html
@@ -10,10 +10,15 @@
     Data Science, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/6-1-computer-and-information-research-scientists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Computer and Information Research Scientists | Tying AI">
     <meta property="og:description" content="Explore the world of Computer and Information Research Scientists, the innovators who invent new computing technologies and find new applications for existing ones.">
     <meta property="og:image" content="https://tying.ai/images/wiki/6-1-computer-and-information-research-scientists.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Computer and Information Research Scientists | Tying AI">
+  <meta name="twitter:description" content="Explore the world of Computer and Information Research Scientists, the innovators who invent new computing technologies and find new applications for existing ones.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/6-1-computer-and-information-research-scientists.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/6-10-web-developers-and-digital-designers.html
+++ b/wiki/6-10-web-developers-and-digital-designers.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Web Developer, Digital Designer, Web Design, UX, UI, Front-End, Back-End, HTML, CSS, JavaScript, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/6-10-web-developers-and-digital-designers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Web Developers and Digital Designers | Tying AI">
     <meta property="og:description" content="Learn about Web Developers, who build and maintain websites, and Digital Designers, who create the visual concepts and layouts.">
     <meta property="og:image" content="https://tying.ai/images/wiki/6-10-web-developers-and-digital-designers.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Web Developers and Digital Designers | Tying AI">
+  <meta name="twitter:description" content="Learn about Web Developers, who build and maintain websites, and Digital Designers, who create the visual concepts and layouts.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/6-10-web-developers-and-digital-designers.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/6-2-computer-network-architects.html
+++ b/wiki/6-2-computer-network-architects.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Computer Network Architect, Network Engineer, Network Design, LAN, WAN, Cloud Computing, Network Security, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/6-2-computer-network-architects.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Computer Network Architects | Tying AI">
     <meta property="og:description" content="Learn about Computer Network Architects, the professionals who design and build data communication networks, including local area networks (LANs), wide area networks (WANs), and Intranets.">
     <meta property="og:image" content="https://tying.ai/images/wiki/6-2-computer-network-architects.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Computer Network Architects | Tying AI">
+  <meta name="twitter:description" content="Learn about Computer Network Architects, the professionals who design and build data communication networks, including local area networks (LANs), wide area networks (WANs), and Intranets.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/6-2-computer-network-architects.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/6-3-computer-programmers.html
+++ b/wiki/6-3-computer-programmers.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Computer Programmer, Coder, Software Developer, Programming, Source Code, Java, Python, C++, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/6-3-computer-programmers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Computer Programmers | Tying AI">
     <meta property="og:description" content="Learn about Computer Programmers, the professionals who write and test the code that allows computer applications and software programs to function.">
     <meta property="og:image" content="https://tying.ai/images/wiki/6-3-computer-programmers.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Computer Programmers | Tying AI">
+  <meta name="twitter:description" content="Learn about Computer Programmers, the professionals who write and test the code that allows computer applications and software programs to function.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/6-3-computer-programmers.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/6-4-computer-support-specialists.html
+++ b/wiki/6-4-computer-support-specialists.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Computer Support Specialist, Help Desk Technician, IT Support, Technical Support, Troubleshooting, Customer Service, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/6-4-computer-support-specialists.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Computer Support Specialists | Tying AI">
     <meta property="og:description" content="Learn about Computer Support Specialists, the IT professionals who provide help and advice to people and organizations using computer software or equipment.">
     <meta property="og:image" content="https://tying.ai/images/wiki/6-4-computer-support-specialists.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Computer Support Specialists | Tying AI">
+  <meta name="twitter:description" content="Learn about Computer Support Specialists, the IT professionals who provide help and advice to people and organizations using computer software or equipment.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/6-4-computer-support-specialists.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/6-5-computer-systems-analysts.html
+++ b/wiki/6-5-computer-systems-analysts.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Computer Systems Analyst, Systems Analyst, IT Consultant, Business Analyst, System Design, Information Technology, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/6-5-computer-systems-analysts.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Computer Systems Analysts | Tying AI">
     <meta property="og:description" content="Learn about Computer Systems Analysts, who study an organization's current computer systems and procedures and design solutions to help the organization operate more efficiently and effectively.">
     <meta property="og:image" content="https://tying.ai/images/wiki/6-5-computer-systems-analysts.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Computer Systems Analysts | Tying AI">
+  <meta name="twitter:description" content="Learn about Computer Systems Analysts, who study an organization's current computer systems and procedures and design solutions to help the organization operate more efficiently and effectively.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/6-5-computer-systems-analysts.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/6-6-database-administrators-and-architects.html
+++ b/wiki/6-6-database-administrators-and-architects.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Database Administrator, DBA, Database Architect, SQL, Data Management, Database Security, Data Modeling, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/6-6-database-administrators-and-architects.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Database Administrators and Architects | Tying AI">
     <meta property="og:description" content="Learn about Database Administrators and Architects, the IT professionals who use specialized software to store, organize, manage, and secure an organization's critical data.">
     <meta property="og:image" content="https://tying.ai/images/wiki/6-6-database-administrators-and-architects.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Database Administrators and Architects | Tying AI">
+  <meta name="twitter:description" content="Learn about Database Administrators and Architects, the IT professionals who use specialized software to store, organize, manage, and secure an organization's critical data.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/6-6-database-administrators-and-architects.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/6-7-information-security-analysts.html
+++ b/wiki/6-7-information-security-analysts.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Information Security Analyst, Cybersecurity, Cyber Security, Network Security, CISSP, Ethical Hacking, Data Security, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/6-7-information-security-analysts.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Information Security Analysts | Tying AI">
     <meta property="og:description" content="Learn about Information Security Analysts, the cybersecurity experts who plan and carry out security measures to protect an organization's computer networks and systems.">
     <meta property="og:image" content="https://tying.ai/images/wiki/6-7-information-security-analysts.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Information Security Analysts | Tying AI">
+  <meta name="twitter:description" content="Learn about Information Security Analysts, the cybersecurity experts who plan and carry out security measures to protect an organization's computer networks and systems.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/6-7-information-security-analysts.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/6-8-network-and-computer-systems-administrators.html
+++ b/wiki/6-8-network-and-computer-systems-administrators.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="System Administrator, Sysadmin, Network Administrator, IT Administration, Server Management, Network Infrastructure, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/6-8-network-and-computer-systems-administrators.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Network and Computer Systems Administrators | Tying AI">
     <meta property="og:description" content="Learn about Network and Computer Systems Administrators, the IT professionals responsible for the day-to-day operation of an organization's computer networks.">
     <meta property="og:image" content="https://tying.ai/images/wiki/6-8-network-and-computer-systems-administrators.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Network and Computer Systems Administrators | Tying AI">
+  <meta name="twitter:description" content="Learn about Network and Computer Systems Administrators, the IT professionals responsible for the day-to-day operation of an organization's computer networks.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/6-8-network-and-computer-systems-administrators.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/6-9-software-developers-quality-assurance-analysts-and-testers.html
+++ b/wiki/6-9-software-developers-quality-assurance-analysts-and-testers.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Software Developer, QA Analyst, Software Tester, SDLC, Agile, Software Engineering, Quality Assurance, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/6-9-software-developers-quality-assurance-analysts-and-testers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Software Developers, QA Analysts, and Testers | Tying AI">
     <meta property="og:description" content="Learn about the distinct but related roles of Software Developers, Quality Assurance (QA) Analysts, and Testers, who are all crucial to the software development lifecycle.">
     <meta property="og:image" content="https://tying.ai/images/wiki/6-9-software-developers-quality-assurance-analysts-and-testers.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Software Developers, QA Analysts, and Testers | Tying AI">
+  <meta name="twitter:description" content="Learn about the distinct but related roles of Software Developers, Quality Assurance (QA) Analysts, and Testers, who are all crucial to the software development lifecycle.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/6-9-software-developers-quality-assurance-analysts-and-testers.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/7-1-boilermakers.html
+++ b/wiki/7-1-boilermakers.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Boilermaker, Skilled Trades, Welding, Metal Fabrication, Industrial Maintenance, Construction, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/7-1-boilermakers.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Boilermakers | Tying AI">
     <meta property="og:description" content="Learn about Boilermakers, the skilled craftspeople who assemble, install, and repair boilers, closed vats, and other large vessels or containers that hold liquids and gases.">
     <meta property="og:image" content="https://tying.ai/images/wiki/7-1-boilermakers.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Boilermakers | Tying AI">
+  <meta name="twitter:description" content="Learn about Boilermakers, the skilled craftspeople who assemble, install, and repair boilers, closed vats, and other large vessels or containers that hold liquids and gases.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/7-1-boilermakers.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/7-2-carpenters.html
+++ b/wiki/7-2-carpenters.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Carpenter, Carpentry, Woodworking, Construction, Framing, Finishing, Skilled Trades, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/7-2-carpenters.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Carpenters | Tying AI">
     <meta property="og:description" content="Learn about Carpenters, the skilled tradespeople who construct, erect, install, and repair structures and fixtures made of wood, plywood, and wallboard.">
     <meta property="og:image" content="https://tying.ai/images/wiki/7-2-carpenters.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Carpenters | Tying AI">
+  <meta name="twitter:description" content="Learn about Carpenters, the skilled tradespeople who construct, erect, install, and repair structures and fixtures made of wood, plywood, and wallboard.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/7-2-carpenters.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">

--- a/wiki/7-3-construction-and-building-inspectors.html
+++ b/wiki/7-3-construction-and-building-inspectors.html
@@ -8,10 +8,15 @@
     <meta name="keywords" content="Building Inspector, Construction Inspector, Code Compliance, Building Codes, Safety Inspection, Skilled Trades, Tying AI">
     <link rel="canonical" href="https://tying.ai/wiki/7-3-construction-and-building-inspectors.html">
   <meta name="robots" content="index, follow">
+  <meta name="author" content="Tying.ai">
   <link rel="stylesheet" href="../wiki.css">
     <meta property="og:title" content="Construction and Building Inspectors | Tying AI">
     <meta property="og:description" content="Learn about Construction and Building Inspectors, the professionals who ensure that construction meets local and national building codes and ordinances, zoning regulations, and contract specifications.">
     <meta property="og:image" content="https://tying.ai/images/wiki/7-3-construction-and-building-inspectors.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Construction and Building Inspectors | Tying AI">
+  <meta name="twitter:description" content="Learn about Construction and Building Inspectors, the professionals who ensure that construction meets local and national building codes and ordinances, zoning regulations, and contract specifications.">
+  <meta name="twitter:image" content="https://tying.ai/og-image.jpg">
     <meta property="og:url" content="https://tying.ai/wiki/7-3-construction-and-building-inspectors.html">
     <meta property="og:type" content="website">
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- add script to update wiki SEO data
- ensure canonical and og:url end with .html
- add author and Twitter meta tags
- provide fallback `og:image` for pages missing it

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68581ed80ce8832087ddb5bbe68e4a55